### PR TITLE
feat: responsive navigation menu

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,7 @@
     <link rel="stylesheet" href="./styles/bootstrap-grid.min.css" />
     <link rel="stylesheet" href="./styles/social-icons.css" />
     <link rel="stylesheet" href="./styles/menu.css" />
+    <link rel="stylesheet" href="./styles/navMenu.css" />
 
     <link rel="stylesheet" href="./styles/style.css" />
   </head>
@@ -55,6 +56,30 @@
         src="assets/images/Logo/logo.svg"
         alt="flock. logo"
       />
+      <div class="nav-menu">
+        <ul>
+          <li>
+            <a class="hamburger__menu--link" data-scroll href="#about-us"
+              >Over ons</a
+            >
+          </li>
+          <li>
+            <a class="hamburger__menu--link" data-scroll href="#our-stories"
+              >Ons verhaal</a
+            >
+          </li>
+          <li>
+            <a class="hamburger__menu--link" data-scroll href="#join-us"
+              >Doe mee</a
+            >
+          </li>
+          <li>
+            <a class="hamburger__menu--link" data-scroll href="#contact"
+              >Contact</a
+            >
+          </li>
+        </ul>
+      </div>
       <div class="outer-menu">
         <input class="checkbox-toggle" type="checkbox" />
         <div class="hamburger">

--- a/src/styles/menu.css
+++ b/src/styles/menu.css
@@ -178,3 +178,9 @@ h1 {
   background: #e5e5e5;
   transition: width 0.4s ease;
 }
+
+@media screen and (min-width: 768px) {
+  .outer-menu {
+    display: none;
+  }
+}

--- a/src/styles/navMenu.css
+++ b/src/styles/navMenu.css
@@ -1,0 +1,21 @@
+.nav-menu {
+  display: none;
+}
+
+.nav-menu ul {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-menu li {
+  margin: 1rem;
+  font-size: 24px;
+}
+
+@media screen and (min-width: 768px) {
+  .nav-menu {
+    display: flex;
+  }
+}


### PR DESCRIPTION
responsive navigation menu which uses the hamburger styled menu
for small and medium devices < 768px and a navbar for larger
devices.

- add media query for outer-menu css class
- add navMenu css file for navigation menu outside of hamburger

Signed-off-by: Tobias Kuppens Groot <tkuppensgroo@uos.de>